### PR TITLE
Add a link to the arxiv pre-print

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Coq-Polyhedra
+**[Link to pre-print: Click here](https://arxiv.org/pdf/1706.10269.pdf)**
 Formalizing convex polyhedra in Coq
 
 ## Installation


### PR DESCRIPTION
It's nice to have a link to the paper pre-print so we don't need to go hunting for the explanation!