### PR TITLE
Use latticePOrderMixin to skip construction of meetSemilatticeMixin

### DIFF
--- a/theories/polyhedron.v
+++ b/theories/polyhedron.v
@@ -586,14 +586,10 @@ by apply: (le_trans d_le_d' _).
 Qed.
 
 Lemma moner_neq0 : -1 != 0 :> R.
-by rewrite eq_sym -addr_eq0 add0r oner_neq0.
-Qed.
+Proof. by rewrite oppr_eq0 oner_eq0. Qed.
 
 Lemma divrNN (x y : R) : (-x)/(-y) = x/y.
-Proof.
-rewrite -[(-x)]mulN1r -[(-y)]mulN1r -mulf_div mulfV ?mul1r //.
-exact: moner_neq0.
-Qed.
+Proof. by rewrite invrN mulrNN. Qed.
 
 Lemma hp_itv (e : lrel[R]_n) (y z: 'cV[R]_n) :
   y \in [hs e] -> z \notin [hs e] ->

--- a/theories/xorder.v
+++ b/theories/xorder.v
@@ -1142,7 +1142,7 @@ End Atomic.
 (* -------------------------------------------------------------------- *)
 Section CoatomAtom.
 Lemma coatom_atom (d : unit) (L : finLatticeType d) (a : L) :
-  coatom a -> atom (L := [finLatticeType of dual L]) a.
+  coatom a -> atom (L := [finLatticeType of L^d]) a.
 Proof.
 case/andP=> gt0_a /existsPn h; apply/andP.
 split; first by apply: gt0_a.
@@ -1150,14 +1150,14 @@ by apply/existsPn => /= x; rewrite andbC h.
 Qed.
 
 Lemma coatom_atom_V (d : unit) (L : finLatticeType d) (a : L) :
-  coatom (L := [finLatticeType of dual L]) a -> atom  a.
+  coatom (L := [finLatticeType of L^d]) a -> atom  a.
 Proof. by apply/coatom_atom. Qed.
 End CoatomAtom.
 
 (* -------------------------------------------------------------------- *)
 Section AtomCoatom.
 Lemma atom_coatom (d : unit) (L : finLatticeType d) (a : L) :
-  atom a -> coatom (L := [finLatticeType of dual L]) a.
+  atom a -> coatom (L := [finLatticeType of L^d]) a.
 Proof.
 case/andP=> gt0_a /existsPn h; apply/andP.
 split; first by apply: gt0_a.
@@ -1165,7 +1165,7 @@ by apply/existsPn => /= x; rewrite andbC h.
 Qed.
 
 Lemma atom_coatom_V (d : unit) (L : finLatticeType d) (a : L) :
-  atom (L := [finLatticeType of dual L]) a -> coatom a.
+  atom (L := [finLatticeType of L^d]) a -> coatom a.
 Proof. by apply/atom_coatom. Qed.
 End AtomCoatom.
 


### PR DESCRIPTION
Also, this PR is compatible with the latest version of math-comp/math-comp#464.